### PR TITLE
Export DarkThemeProvider

### DIFF
--- a/lib/flutterbook.dart
+++ b/lib/flutterbook.dart
@@ -1,4 +1,5 @@
 library flutterbook;
 
 export 'src/flutterbook.dart';
+export 'src/theme_provider.dart';
 export 'src/navigation/models/organizers.dart';


### PR DESCRIPTION
I'd like to dynamically set the `header` widget for our implementation of `Storybook`. Exporting the `DarkThemeProvider` allows us to listen to dark theme toggle events